### PR TITLE
Adding parsing UUIDs from backend as cljs/uuid

### DIFF
--- a/src/untangled/client/impl/network.cljs
+++ b/src/untangled/client/impl/network.cljs
@@ -25,7 +25,9 @@
   (response-error [this xhrio err-cb] "Called by XhrIo on ERROR"))
 
 (defn parse-response [xhr-io]
-  (ct/read (t/reader {:handlers {"f" (fn [v] (js/parseFloat v))}}) (.getResponseText xhr-io)))
+  (ct/read (t/reader {:handlers {"f" (fn [v] (js/parseFloat v))
+                                 "u" cljs.core/uuid}})
+           (.getResponseText xhr-io)))
 
 (defrecord Network [url request-transform global-error-callback complete-app]
   IXhrIOCallbacks


### PR DESCRIPTION
The change is required for compatibility with Prismatic/Schema
