### PR TITLE
Added ability to elide keywords in a union query for data fetches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.5.5
+-----
+- Fixed bug where keywords in a union query were not elided when specified in the `:without` set of data fetches
+
 0.5.4
 -----
 - Added marker option to loads, so that load markers are optional

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [differ "0.2.1"]
                  [lein-doo "0.1.6" :scope "test"]
                  [com.lucasbradstreet/cljs-uuid-utils "1.0.2"]
-                 [navis/untangled-spec "0.3.7-1" :scope "test"]
+                 [navis/untangled-spec "0.3.8" :scope "test"]
                  [org.omcljs/om "1.0.0-alpha41" :scope "provided"]]
 
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]

--- a/spec/untangled/client/data_fetch_spec.cljs
+++ b/spec/untangled/client/data_fetch_spec.cljs
@@ -84,7 +84,15 @@
 
   (behavior "can include parameters when eliding top-level keys from the query"
     (let [ready-state (dfi/ready-state :query (om/get-query Item) :without #{:name} :params {:db/id {:x 1}})]
-      (is (= '[(:db/id {:x 1}) {:comments [:db/id :title {:author [:db/id :username]}]}] (::dfi/query ready-state))))))
+      (is (= '[(:db/id {:x 1}) {:comments [:db/id :title {:author [:db/id :username]}]}] (::dfi/query ready-state)))))
+
+  (behavior "can elide keywords from a union query"
+    (assertions
+      (om/ast->query
+        (dfi/elide-ast-nodes
+          (om/query->ast [{:current-tab {:panel [:data] :console [:data] :dashboard [:data]}}])
+          #{:console}))
+      => [{:current-tab {:panel [:data] :dashboard [:data]}}])))
 
 (specification "Lazy loading"
   (component "Loading a field within a component"


### PR DESCRIPTION
A patch for the below issue with keyword elision in unions during data fetch using the `:without` parameter. A warning is printed should the user try to elide a union keyword for unions of size two.

```
(om/ast->query
  (elide-ast-nodes
    (om/query->ast [{:current-tab {:panel [:data] :console [:data] :dashboard [:data]}}])
    #{:console}))
;; should yield [{:current-tab {:panel [:data] :dashboard [:data]}}]
;; currently returns the input
```
