### PR TITLE
Require clojure.walk in the namespace definitions.

### DIFF
--- a/src/untangled/client/impl/om_plumbing.cljs
+++ b/src/untangled/client/impl/om_plumbing.cljs
@@ -6,6 +6,7 @@
             [untangled.client.mutations :as m]
             [untangled.client.logging :as log]
             [cljs.core.async :as async]
+            [clojure.walk :as walk]
             [clojure.zip :as zip])
   (:require-macros
     [cljs.core.async.macros :refer [go]]))
@@ -58,7 +59,7 @@
   "Replaces all om-tempids in app-state with the ids returned by the server."
   (if (empty? tid->rid)
     state
-    (clojure.walk/prewalk #(if (-> % type (= om.tempid/TempId)) (get tid->rid % %) %) state)))
+    (walk/prewalk #(if (-> % type (= om.tempid/TempId)) (get tid->rid % %) %) state)))
 
 (defn rewrite-tempids-in-request-queue
   "Rewrite any pending requests in the request queue to account for the fact that a response might have
@@ -244,7 +245,7 @@
 
 (defn sweep-missing [result]
   (letfn [(clean [[k v]] (when-not (= v nf) [k v]))]
-    (clojure.walk/prewalk
+    (walk/prewalk
       #(if (map? %)
         (into {} (map clean %)) %)
       result)))

--- a/src/untangled/client/impl/protocol_support.cljs
+++ b/src/untangled/client/impl/protocol_support.cljs
@@ -2,6 +2,7 @@
   (:require
     [untangled-spec.core :refer-macros [assertions behavior]]
     [cljs.test :refer-macros [is]]
+    [clojure.walk :as walk]
     [om.next :as om :refer-macros [defui]]
     [om.dom :as dom]
     [untangled.client.core :as core]))
@@ -14,7 +15,7 @@
   "Rewrite tempid keywords in the given state using the tid->rid map. Leaves the keyword alone if the map
    does not contain an entry for it."
   [state tid->rid & [pred]]
-  (clojure.walk/prewalk #(if ((or pred tempid?) %)
+  (walk/prewalk #(if ((or pred tempid?) %)
                           (get tid->rid % %) %)
     state))
 
@@ -39,7 +40,7 @@
 
 (defn allocate-tempids [tx]
   (let [allocated-ids (atom #{})]
-    (clojure.walk/prewalk
+    (walk/prewalk
       (fn [v] (when (tempid? v) (swap! allocated-ids conj v)) v)
       tx)
     (into {} (map #(vector % (om/tempid)) @allocated-ids))))


### PR DESCRIPTION
This ensures they're included as needed during compilation,
preventing warnings such as

```
WARNING: Use of undeclared Var clojure.walk/prewalk
```

Change-Id: I095c307e0ed842319a36128ad57c7cbf32976b8d
