### PR TITLE
Resolving issues with the app-state marker and fetch states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.5.7
+-----
+- The `:marker` keyword actually works now!
+- Fix: data fetch with parameters places the load marker in the correct location in app state
+- Fix: error callback doesn't attempt to modify data state in app state db when the data state's marker is false
+
 0.5.6
 -----
 - Fixed bug with global-error-callback not being called with a server error returns no body

--- a/src/untangled/client/impl/built_in_mutations.cljs
+++ b/src/untangled/client/impl/built_in_mutations.cljs
@@ -5,7 +5,9 @@
             [untangled.dom :refer [unique-key]]
             [untangled.i18n.core :as i18n]))
 
-(defmethod mutate 'untangled/load [{:keys [state]} _ {:keys [root field query params without post-mutation fallback ident callback parallel refresh]}]
+(defmethod mutate 'untangled/load
+  [{:keys [state]} _ {:keys [root field query params without post-mutation
+                             marker fallback ident callback parallel refresh]}]
   (when callback (log/error "Callback no longer supported. Use post-mutation instead."))
   (when (and post-mutation (not (symbol? post-mutation))) (log/error "post-mutation must be a symbol or nil"))
   {:remote true
@@ -16,6 +18,7 @@
                :field field
                :ident ident
                :query query
+               :marker marker
                :params params
                :without without
                :refresh refresh

--- a/src/untangled/client/impl/data_fetch.cljs
+++ b/src/untangled/client/impl/data_fetch.cljs
@@ -254,7 +254,8 @@
   (let [expr (-> state ::query first)
         key (cond
               (keyword? expr) expr
-              (map? expr) (ffirst expr))]
+              (map? expr) (ffirst expr)
+              (list? expr) (ffirst (first expr)))]
     key))
 
 (defn data-path [state] (if (and (nil? (data-ident state)) (nil? (data-field state)))

--- a/src/untangled/client/impl/data_fetch.cljs
+++ b/src/untangled/client/impl/data_fetch.cljs
@@ -331,9 +331,9 @@
                         (swap! app-state assoc :untangled/server-error error)
                         (doseq [item loading-items]
                           (swap! app-state (fn [s]
-                                             (-> s
-                                                 (update :untangled/loads-in-progress disj (data-uuid item))
-                                                 (update-in (data-path item) set-failed! error))))))
+                                             (cond-> s
+                                               (data-marker? item) (update-in (data-path item) set-failed! error)
+                                               (update :untangled/loads-in-progress disj (data-uuid item)))))))
           run-fallbacks (fn [] (doseq [item loading-items]
                                  (when-let [fallback-symbol (::fallback item)]
                                    (reset! ran-fallbacks true)


### PR DESCRIPTION
- 'untangled/load now passes the `:marker` value through to data fetch #24
- fixed data fetch implementation bug that resolves #22 & #32
