### PR TITLE
Adding jump to and playback speed features to support viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Added ability to pass untangled app, so that use in started-callback is easier.
 - Fixed bug in failed loading markers
 - Fixed bug with removal/addition of markers when markers are off
+- Added jump to and playback speed features to the support viewer.
 
 0.5.7
 -----

--- a/src/untangled/support_viewer.cljs
+++ b/src/untangled/support_viewer.cljs
@@ -11,10 +11,10 @@
 
 (defui ^:once SupportViewerRoot
   static om/IQuery
-  (query [this] [:ui/react-key :current-position :client-time :frames :position :comments])
+  (query [this] [:ui/react-key :playback-speed :current-position :client-time :frames :position :comments])
   Object
   (render [this]
-    (let [{:keys [ui/react-key current-position client-time frames position comments] :or {ui/react-key "ROOT"}} (om/props this)]
+    (let [{:keys [ui/react-key playback-speed current-position client-time frames position comments] :or {ui/react-key "ROOT"}} (om/props this)]
       (dom/div #js {:key react-key :className (str "history-controls " (name position))}
         (dom/button #js {:className "toggle-position" :onClick #(om/transact! this '[(support-viewer/toggle-position)])} (tr "<= Reposition =>"))
         (dom/button #js {:className "history-back" :onClick #(om/transact! this '[(support-viewer/step-back)])} (tr "Back"))
@@ -22,7 +22,18 @@
         (dom/hr nil)
         (dom/span #js {:className "frame"} (trf "Frame {f,number} of {end,number} " :f (inc current-position) :end frames))
         (dom/span #js {:className "timestamp"} (trf "{ts,date,short} {ts,time,long}" :ts client-time))
-        (dom/div #js {:className "user-comments"} comments)))))
+        (dom/div #js {:className "user-comments"} comments)
+        (dom/hr nil)
+        (dom/span #js {:className "playback-speed"} (trf "Playback speed {s,number}" :s playback-speed))
+        (dom/div #js {}
+          (dom/button #js {:className "speed-1" :onClick #(om/transact! this `[(support-viewer/update-playback-speed ~{:playback-speed 1})])} (tr "1x"))
+          (dom/button #js {:className "speed-10" :onClick #(om/transact! this `[(support-viewer/update-playback-speed ~{:playback-speed 10})])} (tr "10x"))
+          (dom/button #js {:className "speed-25" :onClick #(om/transact! this `[(support-viewer/update-playback-speed ~{:playback-speed 25})])} (tr "25x")))
+        (dom/hr nil)
+        (dom/span #js {:className "history-jump-to"} "Jump to:")
+        (dom/div #js {}
+          (dom/button #js {:className "history-beg" :onClick #(om/transact! this '[(support-viewer/go-to-beg)])} (tr "Beginning"))
+          (dom/button #js {:className "history-end" :onClick #(om/transact! this '[(support-viewer/go-to-end)])} (tr "End")))))))
 
 (defn history-entry [history n]
   (let [steps (:steps history)
@@ -49,30 +60,39 @@
   "Create and display a new untangled support viewer on the given app root, with VCR controls to browse through the given history. The support HTML file must include
   a div with app-dom-id (to mount the app) and a div with support-dom-id to mount the viewer controls."
   [support-dom-id AppRoot app-dom-id]
-  (let [app (atom (core/new-untangled-client :networking (net/mock-network)))
+  (let [app    (atom (core/new-untangled-client :networking (net/mock-network)))
         viewer (map->SupportViewer {:app-root    AppRoot
                                     :dom-id      app-dom-id
                                     :application app
                                     :support     (atom (core/new-untangled-client
-                                                         :initial-state {:history          {}
-                                                                         :application      app
-                                                                         :position         :controls-left
-                                                                         :client-time      (js/Date.)
-                                                                         :frames           0
-                                                                         :current-position 0}
-                                                         :started-callback
-                                                         (fn [{:keys [reconciler]}]
-                                                           (load-data reconciler `[(:support-request {:id ~(core/get-url-param "id")})]
-                                                             :post-mutation 'support-viewer/initialize-history))))})]
+                                                        :initial-state {:history          {}
+                                                                        :application      app
+                                                                        :position         :controls-left
+                                                                        :client-time      (js/Date.)
+                                                                        :playback-speed   1
+                                                                        :frames           0
+                                                                        :current-position 0}
+                                                        :started-callback
+                                                        (fn [{:keys [reconciler]}]
+                                                          (load-data reconciler `[(:support-request {:id ~(core/get-url-param "id")})]
+                                                                     :post-mutation 'support-viewer/initialize-history))))})]
     (core/mount viewer SupportViewerRoot support-dom-id)))
 
 (defn history-step [state delta-fn]
-  (let [{:keys [application history]} @state
-        max-idx (dec (count (:steps history)))
-        p (:current-position @state)
-        new-pos (min max-idx (max 0 (delta-fn p)))
-        entry (history-entry history new-pos)
-        tm (-> entry :untangled/meta :client-time)]
+  (let [{:keys [application history playback-speed]} @state
+
+        max-idx        (dec (count (:steps history)))
+        p              (:current-position @state)
+        playback-speed (max 1 playback-speed) ;; Playback speed min is 1.
+        new-pos        (-> p
+                           delta-fn
+                           (- p)  ; Get the delta i.e. (p' - p).
+                           (* playback-speed) ; Multiply delta by the playback speed.
+                           (+ p) ; Apply this new delta to p.
+                           (max 0)
+                           (min max-idx))
+        entry          (history-entry history new-pos)
+        tm             (-> entry :untangled/meta :client-time)]
     (swap! state (fn [s] (-> s
                            (assoc :current-position new-pos)
                            (assoc :client-time tm))))
@@ -109,3 +129,15 @@
                                   :else :controls-left)]
                (swap! state assoc :position new-position)))})
 
+(defmethod m/mutate 'support-viewer/go-to-beg
+  [{:keys [state]} k params]
+  {:action #(history-step state (fn [pos] 0))})
+
+(defmethod m/mutate 'support-viewer/go-to-end
+  [{:keys [state]} k params]
+  {:action #(let [steps (-> @state :history :steps count dec)]
+              (history-step state (fn [pos] steps)))})
+
+(defmethod m/mutate 'support-viewer/update-playback-speed
+  [{:keys [state]} k {:keys [playback-speed]}]
+  {:action #(swap! state assoc :playback-speed playback-speed)})


### PR DESCRIPTION
Here are some features that we used in our app and thought would be useful.
Specifically, stepping through an app state one mutation at a time became very tedious, especially when alot of those mutations are key presses or background mutations triggered by websocket pushes.

**Acceptance Tests:**
- [ ] Load support request.
- [ ] Verify hitting beg and end buttons bring you to the beg and end state.
- [ ] Verify the hitting the playback buttons changes the playback-speed.
- [ ] Verify that with a playback speed of 10, hitting forward and backwards step through the app states in increments of 10.

**Affected Flows:**
- [ ] Support viewer
