### PR TITLE
use (js-obj) instead of #js to avoid error CLJS-1832

### DIFF
--- a/src/untangled/client/data_fetch.cljs
+++ b/src/untangled/client/data_fetch.cljs
@@ -301,9 +301,9 @@
   (def ui-thing2 (om/factory Thing2))
   ```"
   [data-render props & {:keys [ready-render loading-render failed-render not-present-render]
-                        :or   {loading-render (fn [_] (dom/div #js {:className "lazy-loading-load"} "Loading..."))
-                               ready-render   (fn [_] (dom/div #js {:className "lazy-loading-ready"} "Queued"))
-                               failed-render  (fn [_] (dom/div #js {:className "lazy-loading-failed"} "Loading error!"))}}]
+                        :or   {loading-render (fn [_] (dom/div (js-obj :className "lazy-loading-load") "Loading..."))
+                               ready-render   (fn [_] (dom/div (js-obj :className "lazy-loading-ready") "Queued"))
+                               failed-render  (fn [_] (dom/div (js-obj :className "lazy-loading-failed") "Loading error!"))}}]
 
   (let [state (:ui/fetch-state props)]
     (cond


### PR DESCRIPTION
Since Clojurescript 1.9.293, a new bug prevents code that has `#js` into a `:or` destructuring to compile (see http://dev.clojure.org/jira/browse/CLJS-1832). This PR fixes it so we can compile Untangled with CLJS 1.9.293.
