### PR TITLE
fix js-obj calls keys

### DIFF
--- a/src/untangled/client/data_fetch.cljs
+++ b/src/untangled/client/data_fetch.cljs
@@ -301,9 +301,9 @@
   (def ui-thing2 (om/factory Thing2))
   ```"
   [data-render props & {:keys [ready-render loading-render failed-render not-present-render]
-                        :or   {loading-render (fn [_] (dom/div (js-obj :className "lazy-loading-load") "Loading..."))
-                               ready-render   (fn [_] (dom/div (js-obj :className "lazy-loading-ready") "Queued"))
-                               failed-render  (fn [_] (dom/div (js-obj :className "lazy-loading-failed") "Loading error!"))}}]
+                        :or   {loading-render (fn [_] (dom/div (js-obj "className" "lazy-loading-load") "Loading..."))
+                               ready-render   (fn [_] (dom/div (js-obj "className" "lazy-loading-ready") "Queued"))
+                               failed-render  (fn [_] (dom/div (js-obj "className" "lazy-loading-failed") "Loading error!"))}}]
 
   (let [state (:ui/fetch-state props)]
     (cond


### PR DESCRIPTION
While working on another project here I just realized using keywords as keys on `js-obj` makes then generate keys like `":className"` instead of `"className"`. So, before this commit the `:classNames` are not being correctly applied.