### PR TITLE
fix mark missing bug that happens when there is no data for a union query on result

### DIFF
--- a/spec/untangled/client/impl/om_plumbing_spec.cljs
+++ b/spec/untangled/client/impl/om_plumbing_spec.cljs
@@ -331,4 +331,6 @@
         (impl/mark-missing {:b [{:x {:data 1}} {:x {:data 2}}]} [{:b [:x]}]) =fn=> (has-leaves [[:b 0 :x] [:b 1 :x]])
         (impl/mark-missing {:b []} [:a {:b [:x]}]) =fn=> (has-leaves [[:b]])
         "unions are followed"
-        (impl/mark-missing {:a [{:x {:data 1}} {:y {:data 2}}]} [{:a {:b [:x] :c [:y]}}]) =fn=> (has-leaves [[:a 0 :x] [:a 1 :y]])))))
+        (impl/mark-missing {:a [{:x {:data 1}} {:y {:data 2}}]} [{:a {:b [:x] :c [:y]}}]) =fn=> (has-leaves [[:a 0 :x] [:a 1 :y]])
+        "unions leaves data in place when the result is empty"
+        (impl/mark-missing {:a 1} [:a {:z {:b [:x] :c [:y]}}]) =fn=> (has-leaves [[:a]])))))

--- a/src/untangled/client/impl/om_plumbing.cljs
+++ b/src/untangled/client/impl/om_plumbing.cljs
@@ -219,7 +219,7 @@
                                                          (union->query (get q query-key))))
 
                 ;; list union result
-                (union? ?sub-query)
+                (and (union? ?sub-query) (coll? sub-result))
                 (as-> sub-result <>
                       (mapv #(mark-missing % (union->query (get q query-key))) <>)
                       (assoc result-or-not-found query-key <>))


### PR DESCRIPTION
I noticed Untangled did marked a field result as not-found, then tried to get into the next recursion level, causing the script to break when trying to `mapv` over a non-collection.