### PR TITLE
attempt at correct implementation of return value handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 - Fixed bug in failed loading markers
 - Fixed bug with removal/addition of markers when markers are off
 - Added jump to and playback speed features to the support viewer.
-- Added support for Post Mutation parameters.
-- Added support for handling return values from server mutations.
+- Added support for post-mutation parameters in load API.
+- Added support for custom handling of merge of return values from server mutations (see `:mutation-merge` 
+  in `new-untangled-client`).
 - Added support for custom transit handlers on the client side. Server side is coming in a release soon.
 - Added support for turning on/off Om path optimization
 - Fix for latest cljs support (PR 47)

--- a/project.clj
+++ b/project.clj
@@ -4,26 +4,28 @@
   :license {:name "MIT"
             :url  "https://opensource.org/licenses/MIT"}
 
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.229"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha14" :scope "provided"]
+                 [org.clojure/clojurescript "1.9.293" :scope "provided"]
                  [org.clojure/core.async "0.2.391"]
                  [differ "0.2.1"]
                  [devcards "0.2.2" :exclusions [org.omcljs/om org.omcljs/om org.clojure/core.async] :scope "provided"]
                  [lein-doo "0.1.7" :scope "test"]
                  [com.lucasbradstreet/cljs-uuid-utils "1.0.2"]
                  [navis/untangled-spec "0.3.9" :scope "test"]
-                 [org.omcljs/om "1.0.0-alpha46" :scope "provided"]]
+                 [org.omcljs/om "1.0.0-alpha47" :scope "provided"]]
 
   :jvm-opts ["-XX:-OmitStackTraceInFastThrow" "-Xmx512m" "-Xms256m"]
   :clean-targets ^{:protect false} ["resources/private/js" "resources/public/js/test" "resources/public/js/compiled" "target"]
 
-  :resource-paths ["src" "resources"] ; maven deploy to internal artifactory needs src here
+  :resource-paths ["src" "resources"]                       ; maven deploy to internal artifactory needs src here
 
   :plugins [[lein-cljsbuild "1.1.4"]
             [lein-doo "0.1.7"]]
 
   :doo {:build "automated-tests"
         :paths {:karma "node_modules/karma/bin/karma"}}
+
+  :figwheel {:server-port 8080}
 
   :cljsbuild {:builds
               [{:id           "test"

--- a/spec/untangled/client/impl/application_spec.cljs
+++ b/spec/untangled/client/impl/application_spec.cljs
@@ -167,26 +167,29 @@
     (app/sweep-merge {:a 1 :c 2} {:a 2 :c {:b 1}}) => {:a 2 :c {:b 1}}))
 
 (specification "Merge handler"
-  (let [triggers (atom {})
-        state (atom {:sa true})
-        rh (fn [env k v]
-             (assertions "return handler is passed state atom"
-               (-> env :state deref :sa) => true)
-             (swap! triggers assoc k v))]
+  (let [swept-state {:state 1}
+        data-response {:v 1}
+        mutation-response {'f {:x 1 :tempids {1 2}} 'g {:y 2}}
+        mutation-response-without-tempids (update mutation-response 'f dissoc :tempids)
+        response (merge data-response mutation-response)
+        rh (fn [state k v]
+             (assertions
+               "return handler is passed the swept state as a map"
+               state => swept-state
+               "tempids are stripped from return value before calling handler"
+               (:tempids v) => nil)
+             (vary-meta state assoc k v))]
     (when-mocking
       (app/sweep-merge t s) => (do
                                  (assertions
                                    "Passes source, cleaned of symbols, to sweep-merge"
-                                   s => {})
-                                 :return-of-sweep)
+                                   s => {:v 1})
+                                 swept-state)
 
-
-      (assertions
-        "Returns the result of an actual sweep-merge"
-        ;; Function under test:
-        (app/merge-handler state rh {} {'f {:x 1 :tempids {1 2}} 'g {:y 2}}) => :return-of-sweep
-
-        "triggers return-handler on symbols, passing in :result of return (while eliding tempids)"
-        (get @triggers 'f) => {:x 1}
-        (get @triggers 'g) => {:y 2}))))
+      (let [actual (app/merge-handler rh {} response)]
+        (assertions
+          "Returns the swept state reduced over the return handlers"
+          ;; Function under test:
+          actual => swept-state
+          (meta actual) => mutation-response-without-tempids)))))
 


### PR DESCRIPTION
This patch fixes a subtle error with a double-swap on app state that is affecting the return value handler. The patch listed *should* fix it, but I have not tested it yet (nor fixed the automated tests).