### PR TITLE
Check if data-query-key is an ident before wrapping it in a vector.

### DIFF
--- a/src/untangled/client/impl/data_fetch.cljc
+++ b/src/untangled/client/impl/data_fetch.cljc
@@ -306,6 +306,7 @@
   [state]
   (let [target (data-target state)]
     (cond
+      (vector? (data-ident state)) (data-ident state)
       (and (vector? target) (not-empty target)) target
       (and (vector? (data-ident state)) (keyword? (data-field state))) (conj (data-ident state) (data-field state))
       :otherwise [(data-query-key state)])))

--- a/src/untangled/client/impl/data_fetch.cljc
+++ b/src/untangled/client/impl/data_fetch.cljc
@@ -306,7 +306,6 @@
   [state]
   (let [target (data-target state)]
     (cond
-      (vector? (data-ident state)) (data-ident state)
       (and (vector? target) (not-empty target)) target
       (and (vector? (data-ident state)) (keyword? (data-field state))) (conj (data-ident state) (data-field state))
       :otherwise [(data-query-key state)])))

--- a/src/untangled/client/impl/data_fetch.cljc
+++ b/src/untangled/client/impl/data_fetch.cljc
@@ -352,7 +352,9 @@
   "For items that are manually targeted, move them in app state from their result location to their target location."
   [state-atom items]
   (doseq [item items]
-    (let [default-target  [(data-query-key item)]
+    (let [default-target  (if (vector? (data-query-key item))
+                            (data-query-key item)
+                            [(data-query-key item)])
           field-target    (conj (or (data-ident item) []) (::field item))
           explicit-target (or (::target item) [])
           relocate?       (and (not-empty explicit-target)


### PR DESCRIPTION
This addresses a problem with ident-based loads where when trying to place loaded data at the `:target` when loading off an ident, the ident is wrapped in a vector. This results in `(get-in state [[:component/by-id <id>]])` which is always `nil`.